### PR TITLE
Fix broken import: add missing ReadModel and ReadObjective modules (v1.1.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@globalmoo/globalmoo-sdk",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "description": "JavaScript SDK for the globalMOO API",
   "main": "src/index.js",
   "type": "module",

--- a/src/requests/read-model.js
+++ b/src/requests/read-model.js
@@ -1,0 +1,21 @@
+import { BaseRequest } from './base.js';
+import { Model } from '../models/model.js';
+
+export class ReadModel extends BaseRequest {
+  constructor(modelId) {
+    super();
+    this.modelId = modelId;
+  }
+
+  getMethod() {
+    return 'GET';
+  }
+
+  _getPath() {
+    return `models/${this.modelId}`;
+  }
+
+  getResponseType() {
+    return Model;
+  }
+}

--- a/src/requests/read-objective.js
+++ b/src/requests/read-objective.js
@@ -1,0 +1,21 @@
+import { BaseRequest } from './base.js';
+import { Objective } from '../models/objective.js';
+
+export class ReadObjective extends BaseRequest {
+  constructor(objectiveId) {
+    super();
+    this.objectiveId = objectiveId;
+  }
+
+  getMethod() {
+    return 'GET';
+  }
+
+  _getPath() {
+    return `objectives/${this.objectiveId}`;
+  }
+
+  getResponseType() {
+    return Objective;
+  }
+}


### PR DESCRIPTION
## Summary
- v1.1.0 added exports for `ReadModel` and `ReadObjective` in `src/requests/index.js` but the corresponding source files were not committed
- This causes an import error when loading the SDK — **v1.1.0 is completely broken**
- Adds the missing `read-model.js` and `read-objective.js` request modules
- Bumps version to `1.1.1`

## Root Cause
The files existed locally (untracked) during development and testing, so the bug was not caught. When published to npm, the untracked files were not included in the package.

## Test plan
- [ ] Verify `import { ReadModel, ReadObjective } from '@globalmoo/globalmoo-sdk'` works
- [ ] Run existing test suite
- [ ] After merge, create v1.1.1 release to trigger npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)